### PR TITLE
Change the original disk image path to default libvirt disk path

### DIFF
--- a/container/libvirt.go
+++ b/container/libvirt.go
@@ -288,7 +288,7 @@ func (lc *LibvirtContext) domainXml() (string, error) {
                  DefaultMaxCpus:   2,
                  DefaultMaxMem:    128,
 		 Memory:           128,
-                 OriginalDiskPath: "/home/abhishek/Documents/Works/cloudInit/disk.img.orig",
+                 OriginalDiskPath: "/var/lib/libvirt/images/disk.img.orig",
 		}
 
         // Create directory for seed image and delta disk image


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Change the original disk image path to default libvirt disk path

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: Harshal Patil <harshalp@linux.vnet.ibm.com>